### PR TITLE
Master4.9

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rtems (4.9.6-5) unstable; urgency=medium
+
+  * fix lintian error - rtems-common: unstripped-binary-or-object
+
+ -- Joachim Rahn <Joachim.Rahn@helmholtz-berlin.de>  Thu, 03 Mar 2016 12:56:43 +0100
+
 rtems (4.9.6-4) unstable; urgency=medium
 
   * set USE_COM1_AS_CONSOLE=1 BSP_PRESS_KEY_FOR_RESET=0

--- a/debian/rules
+++ b/debian/rules
@@ -90,6 +90,7 @@ override_dh_auto_install:
 
 override_dh_strip:
 	dh_strip_rtems "$@"
+	dh_strip --package=rtems-common
 
 override_dh_shlibdeps:
 	dh_shlibdeps "$@" -XRTEMS -Xrtems -Xdebug


### PR DESCRIPTION
Build fails because lintian throws error "rtems-common: unstripped-binary-or-object"

The added override in debian/rules explicitly removes the symbols from the binaries in package rtems-common. This should be o.k. because the binaries in rtems-common are binaries running on the build host and not on the target.
